### PR TITLE
hotfix-description Updated README to correct branch and ticket name

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ Expected response: downloadable CSV file with the performed operations.
 
 For any contribution, please:
 
-Create a branch with the same name as the ticket `rnp-t<ID>`
-Each commit must be linked to a Jira ticket and follow the format `rnp-t<ID> - Commit description`
+Create a branch with the same name as the ticket `rpn-t<ID>`
+Each commit must be linked to a Jira ticket and follow the format `rpn-t<ID> - Commit description`
 Make a PR to the `dev` branch
 
 Follow the code style (Black formatting + type hints)


### PR DESCRIPTION
This pull request includes a small fix to the `README.md` file. The change corrects a typo in the branch naming convention and commit message format, replacing `rnp-t<ID>` with `rpn-t<ID>` to ensure consistency with the intended naming standard.