### PR TITLE
Second Release: Stable Version with Better Tests

### DIFF
--- a/app/core/rpn.py
+++ b/app/core/rpn.py
@@ -23,6 +23,9 @@ def rpn_calculator(expression: str) -> float:
             except IndexError:
                 raise ValueError("Insufficient operands")
 
+            if token == "/" and b == 0:
+                raise ZeroDivisionError("Division by zero is not allowed.")
+
             stack.append(calculation_dictionary[token](a, b))
         else:
             try:

--- a/tests/test_rpn.py
+++ b/tests/test_rpn.py
@@ -1,60 +1,38 @@
+import pytest
 from app.core.rpn import rpn_calculator
 
 def test_rpn_calculator():
     assert rpn_calculator("5 1 2 + 4 * + 3 -") == 14.0
 
 def test_rpn_invalid_operator():
-    try:
+    with pytest.raises(ValueError, match="Invalid token|operator"):
         rpn_calculator("2 3 &")
-        assert False, "Should raise ValueError for invalid operator"
-    except ValueError:
-        pass
 
 def test_rpn_insufficient_operands():
-    try:
+    with pytest.raises(ValueError, match="Insufficient operands"):
         rpn_calculator("2 +")
-        assert False, "Should raise ValueError for insufficient operands"
-    except ValueError:
-        pass
 
 def test_rpn_empty_expression():
-    try:
+    with pytest.raises(ValueError, match="Empty expression"):
         rpn_calculator("")
-        assert False, "Should raise ValueError for empty expression"
-    except ValueError:
-        pass
 
 def test_rpn_division_by_zero():
-    try:
+    with pytest.raises(ZeroDivisionError, match="Division by zero is not allowed"):
         rpn_calculator("4 0 /")
-        assert False, "Should raise ZeroDivisionError for division by zero"
-    except ZeroDivisionError:
-        pass
 
 def test_rpn_too_many_operands():
-    try:
+    with pytest.raises(ValueError):
         rpn_calculator("2 3 4 +")
-        assert False, "Should raise ValueError for too many operands left"
-    except ValueError:
-        pass
 
 def test_rpn_only_operators():
-    try:
+    with pytest.raises(ValueError):
         rpn_calculator("+ - * /")
-        assert False, "Should raise ValueError for operators without operands"
-    except ValueError:
-        pass
 
 def test_rpn_whitespace_only():
-    try:
+    with pytest.raises(ValueError):
         rpn_calculator("   ")
-        assert False, "Should raise ValueError for whitespace-only expression"
-    except ValueError:
-        pass
 
 def test_rpn_non_numeric_token():
-    try:
+    with pytest.raises(ValueError):
         rpn_calculator("2 a +")
-        assert False, "Should raise ValueError for non-numeric token"
-    except ValueError:
-        pass
+


### PR DESCRIPTION


# Hotfix RPN Test

## Pull Request Overview

This hotfix adds explicit division-by-zero handling in the RPN calculator and modernizes exception tests using pytest.raises.

- Added a ZeroDivisionError for division-by-zero cases in rpn\_calculator
- Updated tests to use pytest\.raises with some regex matching for error messages
- Left a few tests without match parameters for future refinement

### Reviewed Changes

Copilot reviewed 2 out of 2 changed files in this pull request and generated 1 comment.

| File | Description |
| --------------------- | ----------------------------------------------------------------- |
| tests/test_rpn.py | Replaced try/except blocks with pytest\.raises, added some match patterns |
| app/core/rpn.py | Inserted a check to raise ZeroDivisionError when dividing by zero |

